### PR TITLE
chore(ci): drop Node 18, add Node 24 to test matrix

### DIFF
--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [18.x, 20.x, 22.x]
+                node-version: [20.x, 22.x, 24.x]
 
         steps:
             - name: Checkout code


### PR DESCRIPTION
## Summary
- Drop Node 18.x from CI test matrix (EOL April 2025)
- Add Node 24.x (latest LTS - Krypton)
- Matrix now tests: Node 20, 22, 24

This unblocks dependency PRs like #145 (ESLint v10) and #185 (TypeScript v6) which require Node 20+.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)