### PR TITLE
chore(renovate): extend shared TypeScript preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,8 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "enabled": true,
     "dependencyDashboard": false,
-    "extends": ["config:base"]
+    "extends": [
+        "config:recommended",
+        "github>jheddings/regula:typescript"
+    ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,5 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "enabled": true,
     "dependencyDashboard": false,
-    "extends": [
-        "config:recommended",
-        "github>jheddings/regula:typescript"
-    ]
+    "extends": ["config:recommended", "github>jheddings/regula:typescript"]
 }


### PR DESCRIPTION
Points Renovate at the shared TypeScript preset in [regula](https://github.com/jheddings/regula).

`@typescript-eslint/*` declares a `peerDependencies` range on `typescript`, so a new TypeScript major cannot install until typescript-eslint widens that range. Until it does, the upgrade PR sits red with `ERESOLVE` — and stays there until someone notices it has gone green.

The preset groups `typescript` with the typescript-eslint packages, so the enabling release lands in the same PR as the major and the upgrade resolves atomically.

Also replaces `config:base`, which is deprecated, with `config:recommended`.
